### PR TITLE
Make TYPO3 v11 version of this extension available for PHP 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "typo3-cms-extension",
 	"description": "A TYPO3 CMS extension to translate pages, content and records with DeepL",
 	"require": {
-		"php": ">=8.0.0,<8.2.0",
+		"php": ">=8.0.0,<8.3.0",
 		"typo3/cms-core": "^11.5",
 		"typo3/cms-backend": "*",
 		"deeplcom/deepl-php": "^1.5",


### PR DESCRIPTION
I tested this release of your extension in a TYPO3 project with TYPO3 v11 and PHP 8.2.15. Everything works just fine. It would be nice to have an official release with PHP 8.2 support.

Thanks :)