### PR TITLE
Bugfix accessing renderType for input fields

### DIFF
--- a/Classes/Service/DeeplTranslationService.php
+++ b/Classes/Service/DeeplTranslationService.php
@@ -408,8 +408,8 @@ class DeeplTranslationService implements SingletonInterface
             $result = false;
         } elseif (($tcaConfiguration['l10n_mode'] ?? '') === 'exclude') {
             $result = false;
-        } elseif ($tcaConfiguration['translateWithDeepl'] ?? false) {
-            $result = true;
+        } elseif (isset($tcaConfiguration['translateWithDeepl'])) {
+            $result = (bool)$tcaConfiguration['translateWithDeepl'];
         } elseif ($tcaConfiguration['config']['type'] === 'input') {
             $result = true;
             if (isset($tcaConfiguration['config']['renderType']) && $tcaConfiguration['config']['renderType'] !== 'default') {

--- a/Classes/Service/DeeplTranslationService.php
+++ b/Classes/Service/DeeplTranslationService.php
@@ -412,7 +412,7 @@ class DeeplTranslationService implements SingletonInterface
             $result = true;
         } elseif ($tcaConfiguration['config']['type'] === 'input') {
             $result = true;
-            if (isset($tcaConfiguration['renderType']) && $tcaConfiguration['renderType'] !== 'default') {
+            if (isset($tcaConfiguration['config']['renderType']) && $tcaConfiguration['config']['renderType'] !== 'default') {
                 // Not the usual input
                 $result = false;
             }


### PR DESCRIPTION
`$tcaConfiguration['config']['type'] === 'input'` uses `$tcaConfiguration['renderType']` which I think is wrong.
`$tcaConfiguration['config']['type'] === 'text'` uses `$tcaConfiguration['config']['renderType']` which is correct so use this also for type `input`