### PR TITLE
Make it possible to exclude certain fields via translateWithDeepl

### DIFF
--- a/Classes/Service/DeeplTranslationService.php
+++ b/Classes/Service/DeeplTranslationService.php
@@ -408,8 +408,8 @@ class DeeplTranslationService implements SingletonInterface
             $result = false;
         } elseif (($tcaConfiguration['l10n_mode'] ?? '') === 'exclude') {
             $result = false;
-        } elseif ($tcaConfiguration['translateWithDeepl'] ?? false) {
-            $result = true;
+        } elseif (isset($tcaConfiguration['translateWithDeepl'])) {
+            $result = (bool)$tcaConfiguration['translateWithDeepl'];
         } elseif ($tcaConfiguration['config']['type'] === 'input') {
             $result = true;
             if (isset($tcaConfiguration['renderType']) && $tcaConfiguration['renderType'] !== 'default') {


### PR DESCRIPTION
At the moment it's only possible to force inclusion to translatable fields but it's not possible to force exclusion. This change checks, if translateWithDeepl is set in the configuration. If not, everything works like before. If sit is set, the result is the bool casted value of translateWithDeepl, so it can be true or false.