### PR TITLE
[BUGFIX] Handle null fieldValue in DeeplTranslationService

### DIFF
--- a/Classes/Service/DeeplTranslationService.php
+++ b/Classes/Service/DeeplTranslationService.php
@@ -445,7 +445,7 @@ class DeeplTranslationService implements SingletonInterface
             $result = true;
         }
 
-        $event = GeneralUtility::makeInstance(CanFieldBeTranslatedCheckEvent::class, $tableName, $fieldName, $fieldValue, $result);
+        $event = GeneralUtility::makeInstance(CanFieldBeTranslatedCheckEvent::class, $tableName, $fieldName, $fieldValue ?? '', $result);
         $this->eventDispatcher->dispatch($event);
         $result = $event->getCanBeTranslated();
 


### PR DESCRIPTION
If a field contains the value NULL, it generates an error if I want to create a translated content. With a default TYPO3 12 installation, this occurred (in my case) with the field "rowDescription" in the table "pages".

- TYPO3 12.4.14
- PHP 8.2.15 (DDEV)