### PR TITLE
[BUGFIX]: allow enable module for editors and groups

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -4,7 +4,7 @@ if (\TYPO3\CMS\Core\Core\Environment::isComposerMode()) {
     return [
         'site_DdDeeplDdDeepl' => [
             'parent' => 'site',
-            'access' => 'user,group',
+            'access' => 'user',
             'workspaces' => 'live',
             'icon' => 'EXT:dd_deepl/Resources/Public/Images/DeepL.svg',
             'labels' => 'LLL:EXT:dd_deepl/Resources/Private/Language/locallang.xlf',


### PR DESCRIPTION
Due to changes in module registry, nowadays no more list, but lowest access level must be provided. Otherwise, the option to enable in BE user(group) / Access Rights (Tab) / Modules won't appear.