### PR TITLE
Fallback to DeepL autodetection if source language is unsupported

### DIFF
--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -106,6 +106,14 @@ class Configuration
     }
 
     /**
+     * Fetches amount of glossaries.
+     */
+    public function getCountGlossaries(): int
+    {
+        return count($this->glossaries);
+    }
+
+    /**
      * Fetches maximum number of glossaries per language pair.
      *
      * @return int

--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -108,9 +108,9 @@ class Configuration
     /**
      * Fetches amount of glossaries.
      */
-    public function getCountGlossaries(): int
+    public function getCountGlossaries(Translator $translator): int
     {
-        return count($this->glossaries);
+        return count($translator->listGlossaries());
     }
 
     /**

--- a/Classes/Service/DeeplTranslationService.php
+++ b/Classes/Service/DeeplTranslationService.php
@@ -78,6 +78,8 @@ class DeeplTranslationService implements SingletonInterface
     protected array $targetLanguages = [];
 
     protected ?Translator $translator = null;
+    
+    protected bool $autoDetectSourceLang = false;
 
     /**
      * Creates the instance of the class.
@@ -393,7 +395,7 @@ class DeeplTranslationService implements SingletonInterface
 
         return empty($text) ? '' : $this->translator->translateText(
             $text,
-            $sourceLanguage,
+            $this->autoDetectSourceLang ? null : $sourceLanguage,
             $targetLanguage,
             $options
         );
@@ -480,11 +482,11 @@ class DeeplTranslationService implements SingletonInterface
         } elseif (!$this->isSupportedLanguage($sourceLanguage, $this->sourceLanguages)) {
             $this->logger->notice(
                 sprintf(
-                    'Language "%s" cannot be used as a source language because it is not supported',
+                    'Language "%s" is not supported as a source language. Will try to proceed using DeepL autodetection',
                     $sourceLanguage->getLocale()->getLanguageCode()
                 )
             );
-            $canTranslate = false;
+            $this->autoDetectSourceLang = true;
         } elseif (!$this->isSupportedLanguage($targetLanguage, $this->targetLanguages)) {
             $this->logger->notice(
                 sprintf(

--- a/Classes/Service/DeeplTranslationService.php
+++ b/Classes/Service/DeeplTranslationService.php
@@ -386,6 +386,18 @@ class DeeplTranslationService implements SingletonInterface
             TranslateTextOptions::PRESERVE_FORMATTING => true,
             TranslateTextOptions::TAG_HANDLING => 'html',
         ];
+        
+        // only necessary for autodetect with potential glossary,
+        // otherwise passing null below is sufficient
+        if ($this->autoDetectSourceLang && $this->configuration->getCountGlossaries() > 0) {
+            $sourceLanguage = $this->translator->translateText(
+                $text,
+                null,
+                $targetLanguage,
+                $options
+            )->detectedSourceLang;
+        }
+
         [$sourceLanguageForGlossary] = explode('-', $sourceLanguage);
         [$targetLanguageForGlossary] = explode('-', $targetLanguage);
         $glossary = $this->configuration->getGlossaryForLanguagePair($sourceLanguageForGlossary, $targetLanguageForGlossary);
@@ -395,7 +407,7 @@ class DeeplTranslationService implements SingletonInterface
 
         return empty($text) ? '' : $this->translator->translateText(
             $text,
-            $this->autoDetectSourceLang ? null : $sourceLanguage,
+            ($this->autoDetectSourceLang && !$sourceLanguage) ? null : $sourceLanguage,
             $targetLanguage,
             $options
         );

--- a/Classes/Service/DeeplTranslationService.php
+++ b/Classes/Service/DeeplTranslationService.php
@@ -389,7 +389,7 @@ class DeeplTranslationService implements SingletonInterface
         
         // only necessary for autodetect with potential glossary,
         // otherwise passing null below is sufficient
-        if ($this->autoDetectSourceLang && $this->configuration->getCountGlossaries() > 0) {
+        if ($this->autoDetectSourceLang && $this->configuration->getCountGlossaries($this->translator) > 0) {
             $sourceLanguage = $this->translator->translateText(
                 $text,
                 null,


### PR DESCRIPTION
Ran across this with a project, where we're using a mixed language source (locale `xx-XX`), for a "show in original language" feature on the translated pages. This is likely a rare edge case, so I'd understand if you don't want to support this. Would be appreciated though! :smiley: 