### PR TITLE
[BUGFIX] Prevent throw on empty source record

### DIFF
--- a/Classes/Hook/DataHandlerTranslationHook.php
+++ b/Classes/Hook/DataHandlerTranslationHook.php
@@ -83,8 +83,11 @@ class DataHandlerTranslationHook
                         $targetLanguage = $site->getLanguageById($fieldArray[$languageField]);
                         $translationSourceField = $GLOBALS['TCA'][$tableName]['ctrl']['transOrigPointerField'];
                         $sourceRecord = BackendUtility::getRecord($tableName, $fieldArray[$translationSourceField]);
-                        $translatedFieldArray = $service->translateRecord($tableName, $sourceRecord, $targetLanguage);
-                        ArrayUtility::mergeRecursiveWithOverrule($fieldArray, $translatedFieldArray);
+                        // TODO: investigate when/why this happens
+                        if ($sourceRecord) {
+                            $translatedFieldArray = $service->translateRecord($tableName, $sourceRecord, $targetLanguage);
+                            ArrayUtility::mergeRecursiveWithOverrule($fieldArray, $translatedFieldArray);
+                        }
                     } catch (SiteNotFoundException) {
                         // Nothing to do, record is outside of sites
                     } catch (\InvalidArgumentException) {


### PR DESCRIPTION
@dmitryd Had a case where translation would get stuck on some records with the following message:
```
Uncaught TYPO3 Exception: Dmitryd\DdDeepl\Service\DeeplTranslationService::translateRecord(): Argument #2 ($record) must be of type array, null given, called in .../vendor/dmitryd/dd-deepl/Classes/Hook/DataHandlerTranslationHook.php on line 86
```
Didn't have time to investigate this further, but this seemed to resolve the issue without causing any noticable problem with the translated records. This was a "standard" site using an unmodified `dd_deepl v12.7.0`. Languages were `en` -> `es`. A  glossary was used.