### PR TITLE
12.x [FEATURE] add cache for fetching the possible languages list

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -17,3 +17,12 @@ services:
 
   Dmitryd\DdDeepl\Hook\DataHandlerTranslationHook:
     public: true
+
+  cache.deepl_cache:
+    class: TYPO3\CMS\Core\Cache\Frontend\FrontendInterface
+    factory: ['@TYPO3\CMS\Core\Cache\CacheManager', "getCache"]
+    arguments: ["dd_deepl"]
+
+  Dmitryd\DdDeepl\Service\DeeplTranslationService:
+    arguments:
+      - "@cache.deepl_cache"

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -6,4 +6,7 @@ if (!\TYPO3\CMS\Core\Core\Environment::isCli()) {
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess'][1689870161] = \Dmitryd\DdDeepl\Hook\InjectAdditionalResources::class . '->inject';
 
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('@import \'EXT:dd_deepl/Configuration/TSConfig/PageTSConfig.tsconfig\'');
+
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['dd_deepl'] ??= [];
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['dd_deepl']['backend'] ??= \TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend::class;
 }


### PR DESCRIPTION
Loading the languages list on each request is not feasible as an HTTP request for a list of seldom changing languages seems costful. Thus, a cache is proposed for this list with a default duration of 1 hour.

fixes #51