### PR TITLE
[FEATURE] add cache for fetching the possible languages list

### DIFF
--- a/Classes/Service/DeeplTranslationService.php
+++ b/Classes/Service/DeeplTranslationService.php
@@ -43,6 +43,7 @@ use Dmitryd\DdDeepl\Event\BeforeRecordTranslationEvent;
 use Dmitryd\DdDeepl\Event\CanFieldBeTranslatedCheckEvent;
 use Dmitryd\DdDeepl\Event\PreprocessFieldValueEvent;
 use Psr\Log\LoggerAwareTrait;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\DataHandling\SlugHelper;
@@ -87,8 +88,9 @@ class DeeplTranslationService implements SingletonInterface
      * @param array $deeplOptions
      * @throws \DeepL\DeepLException
      */
-    public function __construct(array $deeplOptions = [])
+    public function __construct(FrontendInterface $cache, array $deeplOptions = [])
     {
+        $this->cache = $cache;
         $this->configuration = GeneralUtility::makeInstance(Configuration::class);
         $this->eventDispatcher = GeneralUtility::makeInstance(EventDispatcher::class);
 
@@ -106,24 +108,7 @@ class DeeplTranslationService implements SingletonInterface
             $apiKey = $this->configuration->getApiKey();
             if ($apiKey) {
                 $this->translator = new Translator($apiKey, $deeplOptions);
-                try {
-                    $this->sourceLanguages = $this->translator->getSourceLanguages();
-                    $this->targetLanguages = $this->translator->getTargetLanguages();
-                    foreach ($this->listGlossaries() as $info) {
-                        $this->availableGlossaries[] = $info->glossaryId;
-                    }
-                } catch (\Exception $exception) {
-                    $this->logger->error(
-                        sprintf(
-                            'Exception %s while fetching DeepL languages. Code %d, message "%s". Stack: %s',
-                            get_class($exception),
-                            $exception->getCode(),
-                            $exception->getMessage(),
-                            $exception->getTraceAsString()
-                        )
-                    );
-                    $this->translator = null;
-                }
+                $this->getCachedLanguagesAndGlossaries();
             }
         } else {
             $message = $GLOBALS['LANG']->sL('LLL:EXT:dd_deepl/Resources/Private/Language/locallang.xlf:not_composer');
@@ -140,6 +125,48 @@ class DeeplTranslationService implements SingletonInterface
             $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
             $defaultFlashMessageQueue = $flashMessageService->getMessageQueueByIdentifier();
             $defaultFlashMessageQueue->enqueue($flashMessage);
+        }
+    }
+
+    /**
+     * Tries to get the available source and target languages from the server and caches that result, as else there
+     * would be an API request on each backend page or list impression
+     *
+     * @return void
+     */
+    public function getCachedLanguagesAndGlossaries(): void
+    {
+        $cachedSourceLanguage = $this->cache->get('sourceLanguages');
+        $cachedTargetLanguage = $this->cache->get('targetLanguages');
+        $cachedGlossaries = $this->cache->get('glossaries');
+
+        if ($cachedSourceLanguage === false ||$cachedTargetLanguage === false || $cachedGlossaries === false) {
+            try {
+                $this->sourceLanguages = $this->translator->getSourceLanguages();
+                $this->cache->set('sourceLanguages', $this->sourceLanguages, ['dd_deepl'],3600);
+                $this->targetLanguages = $this->translator->getTargetLanguages();
+                $this->cache->set('targetLanguages', $this->targetLanguages, ['dd_deepl'], 3600);
+                foreach ($this->listGlossaries() as $info) {
+                    $this->availableGlossaries[] = $info->glossaryId;
+                }
+                $this->cache->set('glossaries', $this->availableGlossaries, ['dd_deepl'], 3600);
+            } catch (\Exception $exception) {
+                $this->logger->error(
+                    sprintf(
+                        'Exception %s while fetching DeepL languages. Code %d, message "%s". Stack: %s',
+                        get_class($exception),
+                        $exception->getCode(),
+                        $exception->getMessage(),
+                        $exception->getTraceAsString()
+                    )
+                );
+                $this->translator = null;
+            }
+        }
+        else {
+            $this->sourceLanguages = $cachedSourceLanguage;
+            $this->targetLanguages = $cachedTargetLanguage;
+            $this->availableGlossaries = $cachedGlossaries;
         }
     }
 

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -20,3 +20,12 @@ services:
 
   Dmitryd\DdDeepl\Hook\DataHandlerTranslationHook:
     public: true
+
+  cache.deepl_cache:
+    class: TYPO3\CMS\Core\Cache\Frontend\FrontendInterface
+    factory: ['@TYPO3\CMS\Core\Cache\CacheManager', "getCache"]
+    arguments: ["dd_deepl"]
+
+  Dmitryd\DdDeepl\Service\DeeplTranslationService:
+    arguments:
+      - "@cache.deepl_cache"

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -4,4 +4,7 @@ if (!\TYPO3\CMS\Core\Core\Environment::isCli()) {
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][1688827348] = \Dmitryd\DdDeepl\Hook\DataHandlerTranslationHook::class;
 
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess'][1689870161] = \Dmitryd\DdDeepl\Hook\InjectAdditionalResources::class . '->inject';
+
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['dd_deepl'] ??= [];
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['dd_deepl']['backend'] ??= \TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend::class;
 }


### PR DESCRIPTION
Loading the languages list on each request is not feasible as an HTTP request for a list of seldom changing languages seems costful. Thus, a cache is proposed for this list with a default duration of 1 hour.

fixes #51 

This is a forward-port of #52 - I have no 13LTS at hand, but the code differences seem simple, so this should work. At least this should help in adapting it a lot.